### PR TITLE
修复 ragq.yml 配置项错误、增加注释，修改readme表述

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ RWKV-RAG 默认启用 LLM Service（大模型） 、Index Service（知识库索
 LLM service 配置项会影响 RWKV-RAG 系统的嵌入、重排序和问答机器人（RWKV-RAG-CHAT）等服务。重点关注以下配置项：
 
 - base_model_file: RWKV 基底模型的路径，请参考 [RWKV 模型下载](https://rwkv.cn/RWKV-Fine-Tuning/Introduction#%E4%B8%8B%E8%BD%BD%E5%9F%BA%E5%BA%95-rwkv-%E6%A8%A1%E5%9E%8B) 
-- bgem3_path: 嵌入模型的路径，推荐使用: bge-m31
-- rerank_path: 重排序模型的路径，推荐使用: BAAIbge-reranker-v2-m3
+- embedding_path: 嵌入模型的路径 (HF模型文件夹)，推荐使用: bge-m3
+- reranker_path: 重排序模型的路径 (HF模型文件夹)，推荐使用: BAAIbge-reranker-v2-m3
 - state_path:  State 文件的路径
 - num_workers: LLM 服务使用的显卡数量
 - device: 指定 LLM 运行的 GPU ，如果你只有一张显卡则改为 cuda:0

--- a/ragq.yml
+++ b/ragq.yml
@@ -10,16 +10,16 @@ llm: #大模型服务配置项
   front_end:
     host: localhost
     protocol: tcp
-    port: 7781
+    port: 7781  # 内部写死的，勿改
   back_end:
     host: localhost
     protocol: tcp
-    port: 7782
+    port: 7782  # 内部写死的，勿改
   num_workers: 1 #服务使用的显卡数量
   spawn_method: spawn
-  base_model_file: /home/rwkv/Peter/model/base/RWKV-x060-World-7B-v2.1-20240507-ctx4096.pth # RWKV base model 路径
-  bgem3_path: /home/rwkv/Peter/model/bi/bge-m31 # embedding model 路径
-  rerank_path: /home/rwkv/Peter/model/bi/BAAIbge-reranker-v2-m3 # rerank model 路径
+  base_model_file: /home/rwkv/Peter/model/base/RWKV-x060-World-7B-v2.1-20240507-ctx4096.pth # RWKV base model 文件路径
+  embedding_path: /home/rwkv/Peter/model/bi/bge-m31 # embedding model 目录路径
+  reranker_path: /home/rwkv/Peter/model/bi/BAAIbge-reranker-v2-m3 # rerank model 目录路径
   state_path: /home/rwkv/Peter/model/state/qa/rwkv-2.pth # State file 路径
   device: cuda:3 #如果你只有一张显卡，填 cuda:0
 
@@ -29,25 +29,26 @@ index: #知识库服务配置项
   front_end:
     host: localhost
     protocol: tcp
-    port: 7783
+    port: 7783  # 内部写死的，勿改
   back_end:
     host: localhost
     protocol: tcp
-    port: 7784
+    port: 7784  # 内部写死的，勿改
   chroma_path: /home/rwkv/Peter/RaqQ-master/src/services/chroma #知识库储存路径
   chroma_port: 9999
   chroma_host: localhost
   sqlite_db_path: /home/rwkv/Peter/RaqQ-master/src/services/chroma/files_services.db #知识库的向量数据库储存地址
   num_workers: 4
   llm_front_end_url: tcp://localhost:7781
+  
 tuning: # 微调服务配置项
   enabled: true
   service_module: tuning_service
   front_end:
     host: localhost
     protocol: tcp
-    port: 7787
+    port: 7787  # 内部写死的，勿改
   back_end:
     host: localhost
     protocol: tcp
-    port: 7788
+    port: 7788  # 内部写死的，勿改

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+numpy==1.26.4
+packaging==24.1
+torch==2.2.2
 beautifulsoup4==4.12.3
 bitsandbytes==0.43.1
 causal_conv1d==1.4.0
@@ -7,8 +10,6 @@ einops==0.8.0
 PyMuPDF==1.24.4
 FlagEmbedding==1.2.10
 msgpack_python==0.5.6
-numpy==1.26.4
-packaging==24.1
 pandas==2.2.2
 playwright==1.44.0
 pytorch_lightning==1.9.5
@@ -16,7 +17,6 @@ PyYAML==6.0.1
 pyzmq==26.0.3
 rwkv==0.8.26
 streamlit==1.35.0
-torch==2.2.2
 transformers==4.42.3
 triton==2.2.0
 wandb==0.17.6


### PR DESCRIPTION
**llm** 配置项下的 **bgem3_path** 与 **rerank_path** 在源码实现中已更改为 **embedding_path** 与 **reranker_path** 而配置文件 **ragq.yml** 未更改

**requirements.txt** 原来的包列表在 **pip install -r** 时会出现依赖错误